### PR TITLE
fix vm not booting on 7.X.X

### DIFF
--- a/retro.xml
+++ b/retro.xml
@@ -104,7 +104,6 @@
       <binary path='/usr/libexec/virtiofsd' xattr='on'>
         <cache mode='always'/>
         <sandbox mode='chroot'/>
-        <lock posix='on' flock='on'/>
       </binary>
       <source dir='/mnt/user/retronas'/>
       <target dir='retronas'/>


### PR DESCRIPTION
fixing vm no bootable device on unraid 7.X.X
removed line 107L: "<lock posix=’on’ flock=’on’/>"